### PR TITLE
feat: remove public ipv4 access from worker nodes

### DIFF
--- a/modules/hetzner/k3s.tf
+++ b/modules/hetzner/k3s.tf
@@ -35,14 +35,20 @@ module "k3s" {
   workers = {
     for i, p in local.k3s_worker_pools : p.pool => {
       name             = hcloud_server.workers[i].name
-      node-external-ip = hcloud_server.workers[i].ipv4_address
-      node-ip          = tolist(hcloud_server.workers[i].network)[0].ip
+      node-external-ip = hcloud_server.workers[i].ipv6_address
+      node-ip          = one(hcloud_server.workers[i].network[*].ip)
 
       connection = {
-        host        = hcloud_server.workers[i].ipv4_address
+        host        = one(hcloud_server.workers[i].network[*].ip)
         port        = var.ssh_port
         private_key = var.ssh_key
         user        = local.ssh_user
+
+        # Always go through the first manager
+        bastion_host        = hcloud_server.manager[0].ipv4_address
+        bastion_user        = local.ssh_user
+        bastion_private_key = var.ssh_key
+        bastion_port        = var.ssh_port
       }
     }...
   }

--- a/modules/hetzner/server.tf
+++ b/modules/hetzner/server.tf
@@ -110,7 +110,7 @@ resource "hcloud_server" "workers" {
   }
 
   public_net {
-    ipv4_enabled = true
+    ipv4_enabled = false
     ipv6_enabled = true
   }
 
@@ -146,10 +146,16 @@ resource "ssh_resource" "manager_ready" {
 resource "ssh_resource" "workers_ready" {
   count = length(hcloud_server.workers)
 
-  host        = hcloud_server.workers[count.index].ipv4_address
+  host        = one(hcloud_server.workers[count.index].network[*].ip)
   user        = local.ssh_user
   private_key = var.ssh_key
   port        = var.ssh_port
+
+  # Always go through the first manager
+  bastion_host        = hcloud_server.manager[0].ipv4_address
+  bastion_user        = local.ssh_user
+  bastion_private_key = var.ssh_key
+  bastion_port        = var.ssh_port
 
   timeout     = "5m"
   retry_delay = "5s"


### PR DESCRIPTION
> This doesn't seem to work as Hetzner requires a public network in order to make outgoing connections

There is a nominal charge for IPv4 addresses. Whilst not huge, there isn't really much point in having this if the addresses aren't really necessary

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
