### PR TITLE
fix(metallb): limit ipaddresspool to manager nodes

### DIFF
--- a/modules/kubernetes/local.tf
+++ b/modules/kubernetes/local.tf
@@ -23,4 +23,7 @@ locals {
   kubeconfig_clusters   = try({ for context in local.kubeconfig.clusters : context.name => context.cluster }, {})
   kubeconfig_users      = try({ for context in local.kubeconfig.users : context.name => context.user }, {})
   kubeconfig_by_context = try({ for context, cluster in local.kubeconfig_clusters : context => merge(cluster, local.kubeconfig_users[context]) }, {})
+  manager_nodes = [
+    for n in flatten(data.kubernetes_nodes.cluster.nodes) : n if strcontains(n.metadata[0].name, "manager")
+  ]
 }

--- a/modules/kubernetes/metallb.tf
+++ b/modules/kubernetes/metallb.tf
@@ -41,7 +41,8 @@ resource "kubernetes_config_map_v1" "metallb" {
       }
       spec = {
         addresses = [
-          for n in flatten(data.kubernetes_nodes.cluster.nodes[*].status[*].addresses) : "${n.address}/32" if n.type == "ExternalIP"
+          # Only use managers as ingress IP
+          for n in flatten(local.manager_nodes[*].status[*].addresses) : "${n.address}/32" if n.type == "ExternalIP"
         ]
       }
     })

--- a/registry/components/metallb/generator.yaml
+++ b/registry/components/metallb/generator.yaml
@@ -17,6 +17,13 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list
+      - patch
+  - apiGroups:
       - metallb.io
     resources:
       - ipaddresspools
@@ -45,9 +52,10 @@ metadata:
   namespace: metallb-system
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   backoffLimit: 5
-  ttlSecondsAfterFinished: 30
   template:
     spec:
       containers:
@@ -56,6 +64,9 @@ spec:
           command:
             - bash
             - -c
-            - kubectl get configmap -n metallb-system nodes -o jsonpath='{.data.resource}' | kubectl apply -f -
+          args:
+            - |
+              kubectl get configmap -n metallb-system nodes -o jsonpath='{.data.resource}' | kubectl apply -f -
+              kubectl rollout restart -n metallb-system -l app.kubernetes.io/name=metallb deployment
       restartPolicy: OnFailure
       serviceAccountName: kubectl-metallb-system


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->
The cluster won't work if the managers aren't online, so use the manager nodes for ingress IPs

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
